### PR TITLE
fix: [3909] Fixed regression in android async editing (#3910)

### DIFF
--- a/maven/codenameone-maven-plugin/pom.xml
+++ b/maven/codenameone-maven-plugin/pom.xml
@@ -127,13 +127,11 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
-            <version>5.4.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>5.4.2</version>
             <scope>test</scope>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.apache.commons/commons-vfs2 -->

--- a/maven/core-unittests/pom.xml
+++ b/maven/core-unittests/pom.xml
@@ -65,19 +65,16 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>RELEASE</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>RELEASE</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-params</artifactId>
-            <version>RELEASE</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/maven/designer/pom.xml
+++ b/maven/designer/pom.xml
@@ -115,7 +115,6 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>5.3.1</version>
             <scope>test</scope>
         </dependency>
         

--- a/maven/pom.xml
+++ b/maven/pom.xml
@@ -52,6 +52,8 @@
         <cn1.binaries>${maven.multiModuleProjectDirectory}/target/cn1-binaries</cn1.binaries>
         <jaxb.version>2.3.1</jaxb.version>
         <cn1.build.client.path>${user.home}/.codenameone/CodeNameOneBuildClient.jar</cn1.build.client.path>
+        <junit.jupiter.version>5.9.3</junit.jupiter.version>
+        <junit.version>4.13.2</junit.version>
     </properties>
     <modules>
         <!--<module>codenameone-maven-goals</module>-->
@@ -69,6 +71,13 @@
     </modules>
     <dependencyManagement>
         <dependencies>
+            <dependency>
+                <groupId>org.junit</groupId>
+                <artifactId>junit-bom</artifactId>
+                <version>${junit.jupiter.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
             <dependency>
                 <groupId>org.apache.maven</groupId>
                 <artifactId>maven-model</artifactId>
@@ -194,12 +203,6 @@
                 <version>${project.version}</version>
             </dependency>
             <dependency>
-                <groupId>junit</groupId>
-                <artifactId>junit</artifactId>
-                <version>4.13.1</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
                 <groupId>org.apache.maven</groupId>
                 <artifactId>maven-plugin-api</artifactId>
                 <version>3.3.3</version>
@@ -288,6 +291,12 @@
                 <groupId>com.sun.xml.bind</groupId>
                 <artifactId>jaxb-core</artifactId>
                 <version>2.3.0.1</version>
+            </dependency>
+            <dependency>
+                <groupId>junit</groupId>
+                <artifactId>junit</artifactId>
+                <scope>test</scope>
+                <version>${junit.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/maven/tests/mojo-tests/pom.xml
+++ b/maven/tests/mojo-tests/pom.xml
@@ -17,13 +17,11 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
-            <version>5.4.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>5.4.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
* fix: [3909] Fixed regression in android async editing

Fixes https://github.com/codenameone/CodenameOne/issues/3909

Caused by https://github.com/codenameone/CodenameOne/pull/3905, which fixed https://github.com/codenameone/CodenameOne/issues/3904

* pegged to jupiter version that supports jdk8

* another attempt to fix junit dependency

* attempt to fix junit dependencies

* another attempt to fix junit dependencies